### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Powerful Templating Framework in C++, with a [command-line tool](#command-line
 [![PyPI Version]](https://pypi.python.org/pypi/synth)
 [![Build Status]](https://travis-ci.org/ajg/synth)
 
-[PyPI Version]: https://pypip.in/v/synth/badge.png
+[PyPI Version]: https://img.shields.io/pypi/v/synth.svg
 [Build Status]: https://travis-ci.org/ajg/synth.png?branch=master
 
 Synopsis


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20synth))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `synth`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.